### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Publish NuGet package
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Add GitHub NuGet source
+        run: dotnet nuget add source --username TheVisual --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/TheVisual/index.json"
+      - name: package NuGet package
+        run: dotnet pack Kopeechka\ Library/kopeechka.sln --configuration Release
+      - name: push NuGet package
+        run: dotnet nuget push "Kopeechka Library/kopeechka/bin/Release/*.nupkg" --source github --api-key ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub actions workflow publishes a NuGet package to GitHub's package registry whenever a new version tag is created or pushed to this repository. See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry for more information.

I've tested these changes on my fork. The action should trigger as soon as you publish a `v1.0.0` tag to this repository after merging this PR:
```
git pull
git tag v1.0.0
git push origin v1.0.0
```